### PR TITLE
Added member copy button

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -161,6 +161,12 @@ const Scopes: { [index: string]: Scope } = {
             )
           },
         },
+        {
+          label: "$(clippy) Copy Member to Clipboard",
+          trigger: () => {
+            vscode.env.clipboard.writeText(this.focus.Name)
+          },
+        },
         getInputItem(this.focus, true),
         ...(this.focus.Parameters
           ? [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -162,7 +162,7 @@ const Scopes: { [index: string]: Scope } = {
           },
         },
         {
-          label: "$(clippy) Copy Member to Clipboard",
+          label: "$(clippy) Copy Name to Clipboard",
           trigger: () => {
             vscode.env.clipboard.writeText(this.focus.Name)
           },


### PR DESCRIPTION
Added button that copies the name of the selected API member to the clipboard. I sometimes find it annoying to have to copy out a member, especially for some more complex names. I think this helps the extension serve as a super fast autocompleter and API reference.